### PR TITLE
use substitution syntax for handling file name variations

### DIFF
--- a/exampleBashLoops.sh
+++ b/exampleBashLoops.sh
@@ -1,8 +1,8 @@
 for FILE in *R1_001.fastq.gz
 do
-  TWO=$(echo $FILE | rev | sed s/./2/14 | rev) #Read in R1 file, reverse it, replace the 12th character with a 2, and reverse for R2
-  TRIM1="trimmed/trimmed."${FILE}
-  TRIM2="trimmed/trimmed."${TWO}
+  TWO=${FILE/_R1_/_R2_} # make read pair name
+  TRIM1="trimmed/trimmed.${FILE}"
+  TRIM2="trimmed/trimmed.${TWO}"
   #echo ${TWO}
   #echo ${TRIM1}
   fastp -i ${FILE} -I ${TWO} -o ${TRIM1} -O ${TRIM2}
@@ -13,8 +13,9 @@ done
 
 for FILE in trimmed.*R1_001.fastq.gz
 do
-  TWO=$(echo $FILE | rev | sed s/./2/14 | rev) #Read in R1 file, reverse it, replace the 12th character with a 2, and reverse for R2
-  OUT=${TWO:8:$(${#TWO}-23)} #Remove trimmed, and end. 23 is 8 (trimmed.) + 15 (R1_001.fastq.gz)
+  TWO=${FILE/_R1_/_R2_} # make read pair name
+  OUT=${TWO/trimmed./} # remove trimmed. prefix
+  OUT=${OUT/.fastq.gz/} # remove .fastq.gz
   #echo ${TWO}
   hisat2 --phred33 -x genome -1 ${FILE} -2 ${TWO} -S ${OUT}.sam
 done


### PR DESCRIPTION
These are small changes that go a long way to improve readability. 
See "Parameter Expansion" under https://www.man7.org/linux/man-pages/man1/bash.1.html#EXPANSION for more options. This is the same file as what you get by typing `man bash`.